### PR TITLE
CC-26461 Backporting password reset workflow improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.0",
         "spryker/acl-merchant-portal-extension": "^1.0.0",
         "spryker/kernel": "^3.30.0",
+        "spryker/propel-orm": "^1.0.0",
         "spryker/transfer": "^3.27.0",
         "spryker/user": "^3.17.0",
         "spryker/user-password-reset-extension": "^1.0.0",

--- a/src/Spryker/Zed/UserPasswordReset/Persistence/UserPasswordResetEntityManagerInterface.php
+++ b/src/Spryker/Zed/UserPasswordReset/Persistence/UserPasswordResetEntityManagerInterface.php
@@ -24,4 +24,11 @@ interface UserPasswordResetEntityManagerInterface
      * @return \Generated\Shared\Transfer\ResetPasswordTransfer
      */
     public function updateResetPassword(ResetPasswordTransfer $resetPasswordTransfer): ResetPasswordTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\ResetPasswordTransfer $resetPasswordTransfer
+     *
+     * @return \Generated\Shared\Transfer\ResetPasswordTransfer
+     */
+    public function invalidatePreviousPasswordResets(ResetPasswordTransfer $resetPasswordTransfer): ResetPasswordTransfer;
 }

--- a/src/Spryker/Zed/UserPasswordReset/UserPasswordResetConfig.php
+++ b/src/Spryker/Zed/UserPasswordReset/UserPasswordResetConfig.php
@@ -13,9 +13,11 @@ use Spryker\Zed\Kernel\AbstractBundleConfig;
 class UserPasswordResetConfig extends AbstractBundleConfig
 {
     /**
+     * Default expiration time in seconds, 2h by default.
+     *
      * @var int
      */
-    protected const DAY_IN_SECONDS = 86400;
+    protected const PASSWORD_EXPIRATION_TIME_IN_SECONDS = 7200;
 
     /**
      * @uses \Spryker\Zed\SecurityGui\SecurityGuiConfig::PASSWORD_RESET_PATH
@@ -38,7 +40,7 @@ class UserPasswordResetConfig extends AbstractBundleConfig
      */
     public function getPasswordTokenExpirationInSeconds(): int
     {
-        return static::DAY_IN_SECONDS;
+        return static::PASSWORD_EXPIRATION_TIME_IN_SECONDS;
     }
 
     /**

--- a/tests/SprykerTest/Zed/UserPasswordReset/_support/UserPasswordResetBusinessTester.php
+++ b/tests/SprykerTest/Zed/UserPasswordReset/_support/UserPasswordResetBusinessTester.php
@@ -26,7 +26,7 @@ use Spryker\Zed\UserPasswordReset\Business\UserPasswordResetFacadeInterface;
  * @method void comment($description)
  * @method void pause()
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\PHPMD)
  */
 class UserPasswordResetBusinessTester extends Actor
 {
@@ -38,6 +38,26 @@ class UserPasswordResetBusinessTester extends Actor
     public function getUserPasswordReset(): UserPasswordResetFacadeInterface
     {
         return $this->getLocator()->userPasswordReset()->facade();
+    }
+
+    /**
+     * @param int $idAuthResetPassword
+     *
+     * @return \Generated\Shared\Transfer\ResetPasswordTransfer|null
+     */
+    public function findResetPasswordTransferByIdAuthResetPassword(int $idAuthResetPassword): ?ResetPasswordTransfer
+    {
+        $resetPasswordEntity = $this->createResetPasswordPropelQuery()
+            ->filterByIdAuthResetPassword($idAuthResetPassword)
+            ->findOne();
+
+        if (!$resetPasswordEntity) {
+            return null;
+        }
+
+        return (new ResetPasswordTransfer())->fromArray($resetPasswordEntity->toArray(), true)
+            ->setIdResetPassword($resetPasswordEntity->getIdAuthResetPassword())
+            ->setFkUserId($resetPasswordEntity->getFkUser());
     }
 
     /**


### PR DESCRIPTION
Branch: backport/1.4.1
Ticket: https://spryker.atlassian.net/browse/CC-26461
Version: 1.4.1
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   UserPasswordReset | patch                 |                       |

-----------------------------------------

#### Module UserPasswordReset

##### Change log

Improvements

- Adjusted `UserPasswordResetFacade::isValidPasswordResetToken()` to change the token length to 35 and add a check on the token if it was already used.
- Adjusted `UserPasswordResetFacade::requestPasswordReset()` with the behavior that when a new password reset is expired, previously made reset requests will be invalidated.
- Adjusted `UserPasswordResetConfig::getPasswordTokenExpirationInSeconds()` value to 7200 seconds.